### PR TITLE
Fix lint error in login page

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -5,7 +5,7 @@ import { FcGoogle } from "react-icons/fc";
 import { useEffect } from "react";
 
 export default function LoginPage() {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const router = useRouter();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- remove the unused `session` variable from the login page to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc20aeff98832ba1e76fa1c0ec9644